### PR TITLE
修复 32 位机器内存不对齐导致 panic 问题

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -53,10 +53,10 @@ func (t *Timer) Stop() bool {
 }
 
 type bucket struct {
+	expiration int64
+	
 	mu     sync.Mutex
 	timers *list.List
-
-	expiration int64
 }
 
 func newBucket() *bucket {


### PR DESCRIPTION
https://github.com/RussellLuo/timingwheel/issues/13

atomic 库中有如下说明：
> Bugs
☞ On x86-32, the 64-bit functions use instructions unavailable before the Pentium MMX. On non-Linux ARM, the 64-bit functions use instructions unavailable before the ARMv6k core. On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

https://godoc.org/sync/atomic#pkg-note-bug