### PR TITLE
Fix bucket.Flush

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -124,9 +124,8 @@ func (b *bucket) Flush(reinsert func(*Timer)) {
 
 		e = next
 	}
+	b.SetExpiration(-1)
 	b.mu.Unlock()
-
-	b.SetExpiration(-1) // TODO: Improve the coordination with b.Add()
 
 	for _, t := range ts {
 		reinsert(t)


### PR DESCRIPTION
之前的写法：
```go
b.mu.Unlock()
//如果此时新加入了一个expiration位于currentTime下个tick间隔内的timer，记为A
//则A还是会定位到这个bucket，但是不会将bucket推入delayqueue，因为bucket的expiration不为-1
b.SetExpiration(-1) // TODO: Improve the coordination with b.Add()
//如果再之后，当前tick间隔内没有新的timer进来，那么A就被遗忘了
```

解决方案：
```go
b.SetExpiration(-1)
b.mu.Unlock()
//这样即使再有expiration位于currentTime下个tick间隔内的timer加进来，bucket也会被推入delayqueue
```